### PR TITLE
Refactor GmlClientManager to use LauncherUpdater

### DIFF
--- a/src/Gml.Client/GmlClientManager.cs
+++ b/src/Gml.Client/GmlClientManager.cs
@@ -89,40 +89,8 @@ public class GmlClientManager : IGmlClientManager
 
         _progressChanged.OnNext(100);
 
-        FileReplaceAndRestart(osType, tempFileName, originalFileName);
+        LauncherUpdater.FileReplaceAndRestart(osType, tempFileName, originalFileName);
     }
-
-    private void FileReplaceAndRestart(OsType osType, string newFileName, string originalFileName)
-    {
-        string cmd;
-        switch (osType)
-        {
-            case OsType.Undefined:
-                throw new Exception("Undefined OS type is not supported");
-            case OsType.Linux:
-            case OsType.OsX:
-                cmd = $"sh -c \"while [ -e /proc/{Process.GetCurrentProcess().Id} ]; do sleep 1; done; mv {newFileName} {originalFileName}; exec {originalFileName}\"";
-                Process.Start(cmd);
-                break;
-            case OsType.Windows:
-                cmd = $"/C for /L %N in () do (tasklist | findstr {Process.GetCurrentProcess().Id} >NUL || (move /Y {newFileName} {originalFileName} & start {originalFileName} & exit) & timeout 1) >NUL";
-                var psi = new ProcessStartInfo("CMD.exe", cmd)
-                {
-                    WindowStyle = ProcessWindowStyle.Hidden,
-                    CreateNoWindow = true,
-                };
-                Process.Start(psi);
-                break;
-            default:
-                throw new ArgumentOutOfRangeException(nameof(osType), osType, null);
-        }
-
-        // Singleton application should end to allow script replace its file
-        Environment.Exit(0);
-    }
-
-    [DllImport("libc")]
-    private static extern int Kill(int pid, int sig);
 
     public Task<ResponseMessage<ProfileReadInfoDto?>?> GetProfileInfo(ProfileCreateInfoDto profileDto)
         => _apiProcedures.GetProfileInfo(profileDto);

--- a/src/Gml.Client/Helpers/LauncherUpdater.cs
+++ b/src/Gml.Client/Helpers/LauncherUpdater.cs
@@ -1,0 +1,100 @@
+using System.Diagnostics;
+using Gml.Web.Api.Domains.System;
+
+namespace Gml.Client.Helpers;
+
+public class LauncherUpdater
+{
+    public static void FileReplaceAndRestart(OsType osType, string newFileName, string originalFileName)
+    {
+        int currentProcessId = Process.GetCurrentProcess().Id;
+        string scriptFileName = Path.GetTempFileName();
+        string scriptContent = string.Empty;
+
+        var newFileInfo = new FileInfo(newFileName);
+        var originalFileInfo = new FileInfo(originalFileName);
+
+        switch (osType)
+        {
+            case OsType.Linux:
+            case OsType.OsX:
+                scriptContent = $@"
+#!/bin/bash
+sleep 1
+kill {currentProcessId}
+while [ -e /proc/{currentProcessId} ]; do sleep 0.1; done
+mv ""{newFileInfo.FullName}"" ""{originalFileInfo.FullName}""
+nohup ""{originalFileInfo.FullName}"" &
+rm ""{scriptFileName}""";
+                File.WriteAllText(scriptFileName, scriptContent);
+                ExecuteCommand($"chmod +x \"{scriptFileName}\"", osType);
+                ExecuteCommand($"nohup \"{scriptFileName}\" &", osType, Path.GetDirectoryName(newFileInfo.FullName));
+                break;
+
+            case OsType.Windows:
+                scriptContent = $@"
+@echo off
+timeout /t 1 /nobreak
+taskkill /PID {currentProcessId} /F
+:waitloop
+timeout /t 0.1 >nul
+tasklist /fi ""pid eq {currentProcessId}"" | find /i ""{currentProcessId}"" >nul
+if not errorlevel 1 goto waitloop
+move /Y ""{newFileInfo.FullName}"" ""{originalFileInfo.FullName}""
+start """" ""{originalFileInfo.FullName}""
+del ""{scriptFileName}.bat""";
+                File.WriteAllText(scriptFileName + ".bat", scriptContent);
+                ExecuteCommand($"\"{scriptFileName}.bat\"", osType, Path.GetDirectoryName(newFileInfo.FullName));
+                break;
+
+            default:
+                throw new NotSupportedException("Unsupported OS type.");
+        }
+
+        Environment.Exit(0);
+    }
+
+    private static void ExecuteCommand(string command, OsType osType, string? workingDirectory = null)
+    {
+        ProcessStartInfo processInfo;
+
+        if (osType == OsType.Windows)
+        {
+            processInfo = new ProcessStartInfo("cmd.exe", $"/C {command}")
+            {
+                RedirectStandardError = true,
+                RedirectStandardOutput = true,
+                UseShellExecute = false,
+                CreateNoWindow = true
+            };
+        }
+        else
+        {
+            processInfo = new ProcessStartInfo("bash", $"-c \"{command}\"")
+            {
+                RedirectStandardError = true,
+                RedirectStandardOutput = true,
+                UseShellExecute = false,
+                CreateNoWindow = true
+            };
+        }
+
+        if (workingDirectory is not null)
+        {
+            processInfo.WorkingDirectory = workingDirectory;
+        }
+
+        using (var process = Process.Start(processInfo))
+        {
+            process.WaitForExit();
+            string output = process.StandardOutput.ReadToEnd();
+            string error = process.StandardError.ReadToEnd();
+
+            if (process.ExitCode != 0)
+            {
+                throw new Exception($"Command '{command}' failed with error: {error}");
+            }
+        }
+    }
+
+}


### PR DESCRIPTION
Moved the FileReplaceAndRestart method to a new LauncherUpdater class. This improves code organization and separates responsibilities, making GmlClientManager more focused on its core tasks.